### PR TITLE
Rework `plot_forecast` to handle new functionality for prediction intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Add params_to_tune for DeepStateModel ([#115](https://github.com/etna-team/etna/issues/115))
-- 
+- Handle new functionality for prediction intervals in the `plot_forecast` ([#130](https://github.com/etna-team/etna/pull/130))  
 - 
 - 
 - 

--- a/etna/analysis/forecast/plots.py
+++ b/etna/analysis/forecast/plots.py
@@ -2,8 +2,10 @@ import itertools
 import math
 from copy import deepcopy
 from enum import Enum
+from functools import cmp_to_key
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -24,7 +26,7 @@ from statsmodels.graphics.gofplots import qqplot
 from typing_extensions import Literal
 
 from etna.analysis.forecast.utils import _prepare_forecast_results
-from etna.analysis.forecast.utils import _select_quantiles
+from etna.analysis.forecast.utils import _select_prediction_intervals_names
 from etna.analysis.forecast.utils import _validate_intersecting_segments
 from etna.analysis.forecast.utils import get_residuals
 from etna.analysis.utils import _prepare_axes
@@ -33,6 +35,26 @@ from etna.datasets.utils import match_target_components
 if TYPE_CHECKING:
     from etna.datasets import TSDataset
     from etna.transforms import Transform
+
+
+def _get_borders_comparator(segment_borders: pd.DataFrame) -> Callable[[str, str], int]:
+    """Create comparator function to sort border names."""
+
+    def cmp(name_a: str, name_b: str) -> int:
+        """Compare two series based on their values."""
+        border_a = segment_borders[name_a].values
+        border_b = segment_borders[name_b].values
+
+        if np.all(border_a < border_b):
+            return -1
+        elif np.all(border_a == border_b):
+            return 0
+        elif np.all(border_a > border_b):
+            return 1
+        else:
+            raise ValueError("Detected intersection between non equal borders!")
+
+    return cmp
 
 
 def plot_forecast(
@@ -95,7 +117,7 @@ def plot_forecast(
     _, ax = _prepare_axes(num_plots=len(segments), columns_num=columns_num, figsize=figsize)
 
     if prediction_intervals:
-        quantiles = _select_quantiles(forecast_results, quantiles)
+        prediction_intervals_names = _select_prediction_intervals_names(forecast_results, quantiles)
 
     if train_ts is not None:
         train_ts.df.sort_values(by="timestamp", inplace=True)
@@ -126,7 +148,6 @@ def plot_forecast(
             ax[i].plot(segment_test_df.index.values, segment_test_df.target.values, color="purple", label="test")
 
         # plot forecast plot for each of given forecasts
-        quantile_prefix = "target_"
         for forecast_name, forecast in forecast_results.items():
             legend_prefix = f"{forecast_name}: " if num_forecasts > 1 else ""
 
@@ -140,55 +161,63 @@ def plot_forecast(
             forecast_color = line[0].get_color()
 
             # draw prediction intervals from outer layers to inner ones
-            if prediction_intervals and quantiles is not None:
-                alpha = np.linspace(0, 1 / 2, len(quantiles) // 2 + 2)[1:-1]
-                for quantile_idx in range(len(quantiles) // 2):
+            intervals = forecast.get_prediction_intervals()
+            if prediction_intervals and intervals is not None:
+                alpha = np.linspace(0, 1 / 2, len(prediction_intervals_names) // 2 + 2)[1:-1]
+
+                segment_borders_df = intervals.loc[:, pd.IndexSlice[segment, :]].droplevel(level="segment", axis=1)
+                comparator = _get_borders_comparator(segment_borders=segment_borders_df)
+                prediction_intervals_names = sorted(prediction_intervals_names, key=cmp_to_key(comparator))
+
+                for interval_idx in range(len(prediction_intervals_names) // 2):
                     # define upper and lower border for this iteration
-                    low_quantile = quantiles[quantile_idx]
-                    high_quantile = quantiles[-quantile_idx - 1]
-                    values_low = segment_forecast_df[f"{quantile_prefix}{low_quantile}"].values
-                    values_high = segment_forecast_df[f"{quantile_prefix}{high_quantile}"].values
-                    # if (low_quantile, high_quantile) is the smallest interval
-                    if quantile_idx == len(quantiles) // 2 - 1:
+                    low_border = prediction_intervals_names[interval_idx]
+                    high_border = prediction_intervals_names[-interval_idx - 1]
+                    values_low = segment_borders_df[low_border].values
+                    values_high = segment_borders_df[high_border].values
+
+                    # if (low_border, high_border) is the smallest interval
+                    if interval_idx == len(prediction_intervals_names) // 2 - 1:
                         ax[i].fill_between(
-                            segment_forecast_df.index.values,
+                            segment_borders_df.index.values,
                             values_low,
                             values_high,
                             facecolor=forecast_color,
-                            alpha=alpha[quantile_idx],
-                            label=f"{legend_prefix}{low_quantile}-{high_quantile}",
+                            alpha=alpha[interval_idx],
+                            label=f"{legend_prefix}{low_border}-{high_border}",
                         )
-                    # if there is some interval inside (low_quantile, high_quantile) we should plot around it
+
+                    # if there is some interval inside (low_border, high_border) we should plot around it
                     else:
-                        low_next_quantile = quantiles[quantile_idx + 1]
-                        high_prev_quantile = quantiles[-quantile_idx - 2]
-                        values_next = segment_forecast_df[f"{quantile_prefix}{low_next_quantile}"].values
+                        low_next_border = prediction_intervals_names[interval_idx + 1]
+                        high_prev_border = prediction_intervals_names[-interval_idx - 2]
+                        values_next = segment_borders_df[low_next_border].values
                         ax[i].fill_between(
-                            segment_forecast_df.index.values,
+                            segment_borders_df.index.values,
                             values_low,
                             values_next,
                             facecolor=forecast_color,
-                            alpha=alpha[quantile_idx],
-                            label=f"{legend_prefix}{low_quantile}-{high_quantile}",
+                            alpha=alpha[interval_idx],
+                            label=f"{legend_prefix}{low_border}-{high_border}",
                         )
-                        values_prev = segment_forecast_df[f"{quantile_prefix}{high_prev_quantile}"].values
+                        values_prev = segment_borders_df[high_prev_border].values
                         ax[i].fill_between(
-                            segment_forecast_df.index.values,
+                            segment_borders_df.index.values,
                             values_high,
                             values_prev,
                             facecolor=forecast_color,
-                            alpha=alpha[quantile_idx],
+                            alpha=alpha[interval_idx],
                         )
-                # when we can't find pair quantile, we plot it separately
-                if len(quantiles) % 2 != 0:
-                    remaining_quantile = quantiles[len(quantiles) // 2]
-                    values = segment_forecast_df[f"{quantile_prefix}{remaining_quantile}"].values
+                # when we can't find pair for border, we plot it separately
+                if len(prediction_intervals_names) % 2 != 0:
+                    remaining_border = prediction_intervals_names[len(prediction_intervals_names) // 2]
+                    values = segment_borders_df[remaining_border].values
                     ax[i].plot(
-                        segment_forecast_df.index.values,
+                        segment_borders_df.index.values,
                         values,
                         "--",
                         color=forecast_color,
-                        label=f"{legend_prefix}{remaining_quantile}",
+                        label=f"{legend_prefix}{remaining_border}",
                     )
         ax[i].set_title(segment)
         ax[i].tick_params("x", rotation=45)

--- a/etna/analysis/forecast/plots.py
+++ b/etna/analysis/forecast/plots.py
@@ -45,14 +45,14 @@ def _get_borders_comparator(segment_borders: pd.DataFrame) -> Callable[[str, str
         border_a = segment_borders[name_a].values
         border_b = segment_borders[name_b].values
 
-        if np.all(border_a < border_b):
-            return -1
-        elif np.all(border_a == border_b):
+        if np.all(border_a == border_b):
             return 0
-        elif np.all(border_a > border_b):
+        elif np.all(border_a <= border_b):
+            return -1
+        elif np.all(border_a >= border_b):
             return 1
         else:
-            raise ValueError("Detected intersection between non equal borders!")
+            raise ValueError("Detected intersection between non-equal borders!")
 
     return cmp
 
@@ -104,6 +104,10 @@ def plot_forecast(
     ------
     ValueError:
         if the format of ``forecast_ts`` is unknown
+    ValueError:
+        if there is an intersection between non-equal borders
+    ValueError:
+        if provided quantiles are not in the datasets
     """
     forecast_results = _prepare_forecast_results(forecast_ts)
     num_forecasts = len(forecast_results.keys())

--- a/tests/test_analysis/test_forecast/test_plots.py
+++ b/tests/test_analysis/test_forecast/test_plots.py
@@ -23,12 +23,12 @@ def test_plot_residuals_fails_unkown_feature(example_tsdf):
     "segments_df",
     (
         pd.DataFrame({"a": [0, 1, 2], "b": [2, 1, 0]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 3]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [0, 2, 2]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [1, 1, 2]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [0, 2, 4]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 1, -3]}),
-        pd.DataFrame({"a": [0, 1, 2], "b": [3, 1, 3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 0, 3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 2, 3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 3, 1]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 1, 3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [1, 1, -3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [3, 2, 1]}),
     ),
 )
 def test_compare_error(segments_df):

--- a/tests/test_analysis/test_forecast/test_plots.py
+++ b/tests/test_analysis/test_forecast/test_plots.py
@@ -1,6 +1,8 @@
+import pandas as pd
 import pytest
 
 from etna.analysis import plot_residuals
+from etna.analysis.forecast.plots import _get_borders_comparator
 from etna.metrics import MAE
 from etna.models import LinearPerSegmentModel
 from etna.pipeline import Pipeline
@@ -15,3 +17,36 @@ def test_plot_residuals_fails_unkown_feature(example_tsdf):
     metrics, forecast_df, info = pipeline.backtest(ts=example_tsdf, metrics=[MAE()], n_folds=3)
     with pytest.raises(ValueError, match="Given feature isn't present in the dataset"):
         plot_residuals(forecast_df=forecast_df, ts=example_tsdf, feature="unkown_feature")
+
+
+@pytest.mark.parametrize(
+    "segments_df",
+    (
+        pd.DataFrame({"a": [0, 1, 2], "b": [2, 1, 0]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [0, 2, 2]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [1, 1, 2]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [0, 2, 4]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [-1, 1, -3]}),
+        pd.DataFrame({"a": [0, 1, 2], "b": [3, 1, 3]}),
+    ),
+)
+def test_compare_error(segments_df):
+    comparator = _get_borders_comparator(segment_borders=segments_df)
+    with pytest.raises(ValueError, match="Detected intersection"):
+        _ = comparator(name_a="a", name_b="b")
+
+
+@pytest.mark.parametrize(
+    "segments_df,expected",
+    (
+        (pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 2]}), 0),
+        (pd.DataFrame({"a": [0, 1, 2], "b": [-2, -1, 0]}), 1),
+        (pd.DataFrame({"a": [0, 1, 2], "b": [-1, -2, -3]}), 1),
+        (pd.DataFrame({"a": [0, 1, 2], "b": [1, 2, 3]}), -1),
+        (pd.DataFrame({"a": [0, 1, 2], "b": [3, 2, 3]}), -1),
+    ),
+)
+def test_compare(segments_df, expected):
+    comparator = _get_borders_comparator(segment_borders=segments_df)
+    assert comparator(name_a="a", name_b="b") == expected

--- a/tests/test_analysis/test_forecast/test_utils.py
+++ b/tests/test_analysis/test_forecast/test_utils.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pytest
 
 from etna.analysis import get_residuals
+from etna.analysis.forecast.utils import _get_existing_intervals
+from etna.analysis.forecast.utils import _select_prediction_intervals_names
 from etna.analysis.forecast.utils import _validate_intersecting_segments
 from etna.datasets import TSDataset
 
@@ -42,6 +44,11 @@ def residuals_with_components(residuals):
     df_components = pd.concat([df_component_1, df_component_2], axis=1)
     ts.add_target_components(df_components)
     return residuals_df, forecast_df, ts
+
+
+@pytest.fixture
+def dataset_dict(toy_dataset_equal_targets_and_quantiles):
+    return {"1": toy_dataset_equal_targets_and_quantiles}
 
 
 def test_get_residuals(residuals):
@@ -151,3 +158,21 @@ def test_validate_intersecting_segments_ok(fold_numbers):
 def test_validate_intersecting_segments_fail(fold_numbers):
     with pytest.raises(ValueError):
         _validate_intersecting_segments(fold_numbers)
+
+
+@pytest.mark.parametrize("ts_name", ("example_tsds", "toy_dataset_equal_targets_and_quantiles"))
+def test_get_existing_intervals(ts_name, request):
+    ts = request.getfixturevalue(ts_name)
+    assert _get_existing_intervals(ts) == set(ts.prediction_intervals_names)
+
+
+@pytest.mark.parametrize("quantiles", (None, [0.01]))
+def test_select_prediction_intervals_names(dataset_dict, quantiles):
+    selected_borders = _select_prediction_intervals_names(forecast_results=dataset_dict, quantiles=quantiles)
+    assert selected_borders == ["target_0.01"]
+
+
+@pytest.mark.parametrize("quantiles", ([0.001], [0.1, 0.9]))
+def test_select_prediction_intervals_names_non_existing_quantiles_error(dataset_dict, quantiles):
+    with pytest.raises(ValueError, match="Unable to find provided quantiles"):
+        _ = _select_prediction_intervals_names(forecast_results=dataset_dict, quantiles=quantiles)

--- a/tests/test_analysis/test_forecast/test_utils.py
+++ b/tests/test_analysis/test_forecast/test_utils.py
@@ -176,3 +176,9 @@ def test_select_prediction_intervals_names(dataset_dict, quantiles):
 def test_select_prediction_intervals_names_non_existing_quantiles_error(dataset_dict, quantiles):
     with pytest.raises(ValueError, match="Unable to find provided quantiles"):
         _ = _select_prediction_intervals_names(forecast_results=dataset_dict, quantiles=quantiles)
+
+
+@pytest.mark.parametrize("quantiles", ([0.001, 0.01], [0.01, 0.1, 0.9]))
+def test_select_prediction_intervals_names_extra_quantiles(dataset_dict, quantiles):
+    with pytest.warns(UserWarning, match="Quantiles .* do not exist in each forecast dataset."):
+        _ = _select_prediction_intervals_names(forecast_results=dataset_dict, quantiles=quantiles)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

**Several intervals with quantiles only**
![image](https://github.com/etna-team/etna/assets/60392282/0a1d5177-89c0-46dd-8ea2-f276f1aaeb24)

**Mixed intervals (quantiles and borders)**
![image](https://github.com/etna-team/etna/assets/60392282/4a3a9031-7a90-4703-86a8-bf337d3d002e)

Prediction intervals were obtained in a fixed environment (same pipeline, method, data). 


## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #104 
