### PR TITLE
Fix `ResampleWithDistributionTransform` to work with integer timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - 
 - 
-- 
+- Update `ResampleWithDistributionTransform` to work with integer timestamp ([#165](https://github.com/etna-team/etna/pull/165))
 - 
 - 
 - 

--- a/etna/transforms/missing_values/resample.py
+++ b/etna/transforms/missing_values/resample.py
@@ -44,13 +44,19 @@ class _OneSegmentResampleWithDistributionTransform(OneSegmentTransform):
         Here the ``in_column`` frequency gap is divided into the folds with the size of dataset frequency gap.
         """
         in_column_index = df[self.in_column].dropna().index
-        if len(in_column_index) <= 1 or (len(in_column_index) >= 3 and not pd.infer_freq(in_column_index)):
+
+        fail_datetime_timestamp = (
+            in_column_index.dtype != "int" and len(in_column_index) >= 3 and not pd.infer_freq(in_column_index)
+        )
+        if len(in_column_index) <= 1 or fail_datetime_timestamp:
             raise ValueError(
-                "Can not infer in_column frequency!"
+                "Can not infer in_column frequency! "
                 "Check that in_column frequency is compatible with dataset frequency."
             )
+
         in_column_freq = in_column_index[1] - in_column_index[0]
         dataset_freq = df.index[1] - df.index[0]
+
         n_folds_per_gap = in_column_freq // dataset_freq
         n_periods = len(df) // n_folds_per_gap + 2
 
@@ -110,6 +116,15 @@ class _OneSegmentResampleWithDistributionTransform(OneSegmentTransform):
 
 class ResampleWithDistributionTransform(IrreversiblePerSegmentWrapper):
     """ResampleWithDistributionTransform resamples the given column using the distribution of the other column.
+
+    This transform expects ``in_column`` to have non-NaN values separated by the same number of timestamps to form a cycle.
+    The cycle starts with a non-NaN value and each position has a number from 0 to cycle size - 1.
+
+    During ``fit'', the fraction of each cycle position in a total sum of values is calculated according to ``distribution_column''.
+    During ``transform`` the NaNs within ``in_column`` are filled using the learned distribution.
+
+    The most common application of this transform is to fill NaNs in ``in_column`` that come from data with a different frequency.
+    For example, a dataset has an hourly frequency, but an exogenous variable has only a daily frequency.
 
     Warning
     -------

--- a/tests/test_transforms/test_inference/test_inverse_transform.py
+++ b/tests/test_transforms/test_inference/test_inverse_transform.py
@@ -426,7 +426,6 @@ class TestInverseTransformTrain:
     @pytest.mark.parametrize(
         "transform, dataset_name, expected_changes",
         [
-            # missing_values
             (
                 ResampleWithDistributionTransform(
                     in_column="regressor_exog", distribution_column="target", inplace=True
@@ -434,9 +433,32 @@ class TestInverseTransformTrain:
                 "ts_to_resample",
                 {"change": {"regressor_exog"}},
             ),
+            (
+                ResampleWithDistributionTransform(
+                    in_column="regressor_exog", distribution_column="target", inplace=True
+                ),
+                "ts_to_resample_int_timestamp",
+                {"change": {"regressor_exog"}},
+            ),
         ],
     )
-    def test_inverse_transform_train_datetime_timestamp_fail_resample(
+    def test_inverse_transform_train_fail_resample(self, transform, dataset_name, expected_changes, request):
+        ts = request.getfixturevalue(dataset_name)
+        self._test_inverse_transform_train(ts, transform, expected_changes=expected_changes)
+
+    @pytest.mark.parametrize(
+        "transform, dataset_name, expected_changes",
+        [
+            (
+                ResampleWithDistributionTransform(
+                    in_column="regressor_exog", distribution_column="target", inplace=False, out_column="res"
+                ),
+                "ts_to_resample_int_timestamp",
+                {},
+            ),
+        ],
+    )
+    def test_inverse_transform_train_int_timestamp_non_inplace_resample(
         self, transform, dataset_name, expected_changes, request
     ):
         ts = request.getfixturevalue(dataset_name)

--- a/tests/test_transforms/test_inference/test_transform.py
+++ b/tests/test_transforms/test_inference/test_transform.py
@@ -647,6 +647,29 @@ class TestTransformTrain:
         ts_int_timestamp = convert_ts_to_int_timestamp(ts, bias=10)
         self._test_transform_train(ts_int_timestamp, transform, expected_changes=expected_changes)
 
+    @pytest.mark.parametrize(
+        "transform, dataset_name, expected_changes",
+        [
+            (
+                ResampleWithDistributionTransform(
+                    in_column="regressor_exog", distribution_column="target", inplace=False, out_column="res"
+                ),
+                "ts_to_resample_int_timestamp",
+                {"create": {"res"}},
+            ),
+            (
+                ResampleWithDistributionTransform(
+                    in_column="regressor_exog", distribution_column="target", inplace=True
+                ),
+                "ts_to_resample_int_timestamp",
+                {"change": {"regressor_exog"}},
+            ),
+        ],
+    )
+    def test_transform_train_int_timestamp_resample(self, transform, dataset_name, expected_changes, request):
+        ts = request.getfixturevalue(dataset_name)
+        self._test_transform_train(ts, transform, expected_changes=expected_changes)
+
     @to_be_fixed(raises=Exception)
     @pytest.mark.parametrize(
         "transform, dataset_name, expected_changes",
@@ -727,30 +750,6 @@ class TestTransformTrain:
         ts = request.getfixturevalue(dataset_name)
         ts_int_timestamp = convert_ts_to_int_timestamp(ts, bias=10)
         self._test_transform_train(ts_int_timestamp, transform, expected_changes=expected_changes)
-
-    @to_be_fixed(raises=Exception)
-    @pytest.mark.parametrize(
-        "transform, dataset_name, expected_changes",
-        [
-            (
-                ResampleWithDistributionTransform(
-                    in_column="regressor_exog", distribution_column="target", inplace=False, out_column="res"
-                ),
-                "ts_to_resample_int_timestamp",
-                {"create": {"res"}},
-            ),
-            (
-                ResampleWithDistributionTransform(
-                    in_column="regressor_exog", distribution_column="target", inplace=True
-                ),
-                "ts_to_resample_int_timestamp",
-                {"change": {"regressor_exog"}},
-            ),
-        ],
-    )
-    def test_transform_train_int_timestamp_fail_resample(self, transform, dataset_name, expected_changes, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_transform_train(ts, transform, expected_changes=expected_changes)
 
 
 class TestTransformTrainSubsetSegments:


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #160.

## Closing issues
Closes #160.