### PR TITLE
Update `pytorch_forecasting` models to handle integer timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change warning condition on loading object saved under different library version ([#31](https://github.com/etna-team/etna/issues/31))
 - 
 - 
-- 
+- Update `pytorch_forecasting` models to handle integer timestamp ([#208](https://github.com/etna-team/etna/pull/208))
 - Update `datasets` module to work with integer timestamp ([#146](https://github.com/etna-team/etna/pull/146))
 - 
 - 

--- a/etna/commands/forecast_command.py
+++ b/etna/commands/forecast_command.py
@@ -33,9 +33,8 @@ def compute_horizon(horizon: int, forecast_params: Dict[str, Any], tsdataset: TS
         if forecast_start_timestamp <= train_end_timestamp:
             raise ValueError("Parameter `start_timestamp` should greater than end of training dataset!")
 
-        # TODO: fix this typing in https://github.com/etna-team/etna/milestone/5
         delta = determine_num_steps(
-            start_timestamp=train_end_timestamp, end_timestamp=forecast_start_timestamp, freq=tsdataset.freq  # type: ignore
+            start_timestamp=train_end_timestamp, end_timestamp=forecast_start_timestamp, freq=tsdataset.freq
         )
 
         horizon += delta - 1

--- a/tests/test_models/test_inference/test_forecast.py
+++ b/tests/test_models/test_inference/test_forecast.py
@@ -677,30 +677,6 @@ class TestForecastOutSample:
             (StatsForecastAutoCESModel(), []),
             (StatsForecastAutoETSModel(), []),
             (StatsForecastAutoThetaModel(), []),
-            (NBeatsInterpretableModel(input_size=7, output_size=7, trainer_params=dict(max_epochs=1)), []),
-            (NBeatsGenericModel(input_size=7, output_size=7, trainer_params=dict(max_epochs=1)), []),
-        ],
-    )
-    def test_forecast_out_sample_int_timestamp(self, model, transforms, example_tsds):
-        ts_int_timestamp = convert_ts_to_int_timestamp(example_tsds, shift=-10)
-        self._test_forecast_out_sample(ts_int_timestamp, model, transforms)
-
-    @to_be_fixed(raises=Exception)
-    @pytest.mark.parametrize(
-        "model, transforms",
-        [
-            (ProphetModel(), []),
-            (DeadlineMovingAverageModel(window=1), []),
-            (RNNModel(input_size=1, encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)), []),
-            (
-                DeepARNativeModel(input_size=1, encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)),
-                [],
-            ),
-            (PatchTSModel(encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)), []),
-            (
-                MLPModel(input_size=2, hidden_size=[10], decoder_length=7, trainer_params=dict(max_epochs=1)),
-                [LagTransform(in_column="target", lags=[5, 6])],
-            ),
             (
                 DeepARModel(
                     dataset_builder=PytorchForecastingDatasetBuilder(
@@ -730,6 +706,30 @@ class TestForecastOutSample:
                     lr=0.01,
                 ),
                 [],
+            ),
+            (NBeatsInterpretableModel(input_size=7, output_size=7, trainer_params=dict(max_epochs=1)), []),
+            (NBeatsGenericModel(input_size=7, output_size=7, trainer_params=dict(max_epochs=1)), []),
+        ],
+    )
+    def test_forecast_out_sample_int_timestamp(self, model, transforms, example_tsds):
+        ts_int_timestamp = convert_ts_to_int_timestamp(example_tsds, shift=-10)
+        self._test_forecast_out_sample(ts_int_timestamp, model, transforms)
+
+    @to_be_fixed(raises=Exception)
+    @pytest.mark.parametrize(
+        "model, transforms",
+        [
+            (ProphetModel(), []),
+            (DeadlineMovingAverageModel(window=1), []),
+            (RNNModel(input_size=1, encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)), []),
+            (
+                DeepARNativeModel(input_size=1, encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)),
+                [],
+            ),
+            (PatchTSModel(encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)), []),
+            (
+                MLPModel(input_size=2, hidden_size=[10], decoder_length=7, trainer_params=dict(max_epochs=1)),
+                [LagTransform(in_column="target", lags=[5, 6])],
             ),
             (
                 DeepStateModel(


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #183.

## Closing issues
Closes #183.