### PR TITLE
Fix Catboost `prediction_components`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix number of segments in docs, column name for tourism dataset and change default save path ([#206](https://github.com/etna-team/etna/pull/206))
 - Fix method `to_dict` for `SklearnPerSegmentModel` and `SklearnMultiSegmentModel`([#199](https://github.com/etna-team/etna/pull/199))
 - Fix method `fit` for `MRMRFeatureSelectionTransform` with `redundancy_aggregation_mode`=`median` ([#212](https://github.com/etna-team/etna/pull/212))
+- Fix method `predict_components` for `_CatBoostAdapter` working incorrectly on shuffled columns ([#227](https://github.com/etna-team/etna/pull/227))
 
 
 ## [2.4.0] - 2023-12-15

--- a/etna/models/catboost.py
+++ b/etna/models/catboost.py
@@ -145,8 +145,10 @@ class _CatBoostAdapter(BaseAdapter):
             dataframe with prediction components
         """
         features = df.drop(columns=["timestamp", "target"])
+        self._prepare_float_category_columns(features)
+        predict_pool = Pool(features, cat_features=self._categorical)
+        prediction = self.model.predict(predict_pool)
 
-        prediction = self.model.predict(features)
         pool = self._prepare_pool(features, prediction)
         shap_values = self.model.get_feature_importance(pool, type="ShapValues")
 

--- a/tests/test_models/test_catboost.py
+++ b/tests/test_models/test_catboost.py
@@ -197,9 +197,16 @@ def ts_with_features() -> TSDataset:
 @pytest.mark.parametrize("model", (CatBoostPerSegmentModel(), CatBoostMultiSegmentModel()))
 def test_prediction_decomposition(ts_with_features, model):
     train, test = ts_with_features.train_test_split(test_size=10)
-    test.df = test.df.loc[
-        pd.IndexSlice[:], pd.IndexSlice[:, ["target", "exog", "cat_exog"]]
-    ]  # Order differs from train
+    assert_prediction_components_are_present(model=model, train=train, test=test)
+
+
+@pytest.mark.parametrize("model", (CatBoostPerSegmentModel(), CatBoostMultiSegmentModel()))
+def test_prediction_decomposition_with_shuffled_columns(
+    ts_with_features, model, train_order=("target", "cat_exog", "exog"), test_order=("target", "exog", "cat_exog")
+):
+    train, test = ts_with_features.train_test_split(test_size=10)
+    train.df = train.df.loc[pd.IndexSlice[:], pd.IndexSlice[:, train_order]]
+    test.df = test.df.loc[pd.IndexSlice[:], pd.IndexSlice[:, test_order]]
     assert_prediction_components_are_present(model=model, train=train, test=test)
 
 

--- a/tests/test_models/test_catboost.py
+++ b/tests/test_models/test_catboost.py
@@ -183,9 +183,23 @@ def test_decomposition_sums_to_target(dfs_w_exog):
     np.testing.assert_allclose(y_hat_pred, y_pred)
 
 
+@pytest.fixture
+def ts_with_features() -> TSDataset:
+    df = generate_ar_df(periods=100, n_segments=2, start_time="2000-01-01")
+    df_exog = df.copy().rename(columns={"target": "exog"})
+    df_exog["cat_exog"] = df_exog["exog"].astype(int).astype("category")
+
+    df = TSDataset.to_dataset(df)
+    df_exog = TSDataset.to_dataset(df_exog)
+    return TSDataset(df=df, df_exog=df_exog, freq="D")
+
+
 @pytest.mark.parametrize("model", (CatBoostPerSegmentModel(), CatBoostMultiSegmentModel()))
-def test_prediction_decomposition(outliers_tsds, model):
-    train, test = outliers_tsds.train_test_split(test_size=10)
+def test_prediction_decomposition(ts_with_features, model):
+    train, test = ts_with_features.train_test_split(test_size=10)
+    test.df = test.df.loc[
+        pd.IndexSlice[:], pd.IndexSlice[:, ["target", "exog", "cat_exog"]]
+    ]  # Order differs from train
     assert_prediction_components_are_present(model=model, train=train, test=test)
 
 


### PR DESCRIPTION
## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->
- `prediction_components` worked incorrectly in some cases(i.e. order of columns in test dataframe differs from train) -- add creating Pool out of dataframe

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
