### PR TITLE
Fix `FourierTransform` on integer index, add inference tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `ProphetModel` to handle external timestamp ([#203](https://github.com/etna-team/etna/pull/203))
 - Remove checking frequency in `timestamp_column` of `ProphetModel` ([#222](https://github.com/etna-team/etna/pull/222))
 - Update `FourierTransform` to handle external datetime timestamp ([#223](https://github.com/etna-team/etna/pull/223))
+- Fix `FourierTransform` on integer index, add inference tests ([#230](https://github.com/etna-team/etna/pull/230))
 
 ### Fixed
 - 

--- a/etna/transforms/timestamp/fourier.py
+++ b/etna/transforms/timestamp/fourier.py
@@ -273,7 +273,7 @@ class FourierTransform(IrreversibleTransform):
         self, timestamps: pd.Series, reference_timestamp: pd.Timestamp, freq: Optional[str]
     ) -> pd.Series:
         # we should always align timestamps to some fixed point
-        end_timestamp = timestamps[-1]
+        end_timestamp = timestamps.iloc[-1]
         if end_timestamp >= reference_timestamp:
             end_idx = determine_num_steps(start_timestamp=reference_timestamp, end_timestamp=end_timestamp, freq=freq)
         else:
@@ -304,7 +304,7 @@ class FourierTransform(IrreversibleTransform):
                 timestamps = df.index.to_series()
             else:
                 timestamps = self._convert_regular_timestamps_datetime_to_numeric(
-                    timestamps=df.index, reference_timestamp=self._reference_timestamp, freq=self._freq
+                    timestamps=df.index.to_series(), reference_timestamp=self._reference_timestamp, freq=self._freq
                 )
             features = self._compute_features(timestamps=timestamps)
             features.index = df.index

--- a/tests/test_transforms/test_inference/conftest.py
+++ b/tests/test_transforms/test_inference/conftest.py
@@ -60,7 +60,9 @@ def ts_with_external_timestamp(regular_ts) -> TSDataset:
     df_exog = df.copy()
     df_exog["external_timestamp"] = df["timestamp"]
     df_exog.drop(columns=["target"], inplace=True)
-    ts = TSDataset(df=TSDataset.to_dataset(df).iloc[5:], df_exog=TSDataset.to_dataset(df_exog), freq="D")
+    ts = TSDataset(
+        df=TSDataset.to_dataset(df).iloc[1:-10], df_exog=TSDataset.to_dataset(df_exog), freq="D", known_future="all"
+    )
     return ts
 
 
@@ -70,7 +72,9 @@ def ts_with_external_int_timestamp(regular_ts) -> TSDataset:
     df_exog = df.copy()
     df_exog["external_timestamp"] = np.arange(10, 110).tolist() * 3
     df_exog.drop(columns=["target"], inplace=True)
-    ts = TSDataset(df=TSDataset.to_dataset(df).iloc[5:], df_exog=TSDataset.to_dataset(df_exog), freq="D")
+    ts = TSDataset(
+        df=TSDataset.to_dataset(df).iloc[1:-10], df_exog=TSDataset.to_dataset(df_exog), freq="D", known_future="all"
+    )
     return ts
 
 

--- a/tests/test_transforms/test_inference/test_inverse_transform.py
+++ b/tests/test_transforms/test_inference/test_inverse_transform.py
@@ -391,9 +391,23 @@ class TestInverseTransformTrain:
                 {"change": {"target"}},
             ),
             # timestamp
-            # TODO: fix
+            (
+                DateFlagsTransform(out_column="res"),
+                "regular_ts",
+                {},
+            ),
             (
                 DateFlagsTransform(out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res"),
+                "regular_ts",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
                 {},
             ),
@@ -402,6 +416,8 @@ class TestInverseTransformTrain:
                 "ts_with_external_int_timestamp",
                 {},
             ),
+            (HolidayTransform(out_column="res", mode="binary"), "regular_ts", {}),
+            (HolidayTransform(out_column="res", mode="category"), "regular_ts", {}),
             (
                 HolidayTransform(out_column="res", mode="binary", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
@@ -412,9 +428,15 @@ class TestInverseTransformTrain:
                 "ts_with_external_timestamp",
                 {},
             ),
+            (SpecialDaysTransform(), "regular_ts", {}),
             (
                 SpecialDaysTransform(in_column="external_timestamp"),
                 "ts_with_external_timestamp",
+                {},
+            ),
+            (
+                TimeFlagsTransform(out_column="res"),
+                "regular_ts",
                 {},
             ),
             (
@@ -422,24 +444,6 @@ class TestInverseTransformTrain:
                 "ts_with_external_timestamp",
                 {},
             ),
-            (
-                DateFlagsTransform(out_column="res"),
-                "regular_ts",
-                {},
-            ),
-            (
-                FourierTransform(period=7, order=2, out_column="res"),
-                "regular_ts",
-                {},
-            ),
-            (HolidayTransform(out_column="res", mode="binary"), "regular_ts", {}),
-            (HolidayTransform(out_column="res", mode="category"), "regular_ts", {}),
-            (
-                TimeFlagsTransform(out_column="res"),
-                "regular_ts",
-                {},
-            ),
-            (SpecialDaysTransform(), "regular_ts", {}),
             (EventTransform(in_column="holiday", out_column="holiday", n_pre=1, n_post=1), "ts_with_binary_exog", {}),
             (
                 EventTransform(in_column="holiday", out_column="holiday", n_pre=1, n_post=1, mode="distance"),
@@ -785,6 +789,11 @@ class TestInverseTransformTrain:
             ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
                 {},
             ),
@@ -1041,7 +1050,11 @@ class TestInverseTransformTrainSubsetSegments:
                 DateFlagsTransform(out_column="res", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
             ),
-            (FourierTransform(period=7, order=2), "regular_ts"),
+            (FourierTransform(period=7, order=2, out_column="res"), "regular_ts"),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+            ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
@@ -1281,7 +1294,11 @@ class TestInverseTransformFutureSubsetSegments:
                 DateFlagsTransform(out_column="res", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
             ),
-            (FourierTransform(period=7, order=2), "regular_ts"),
+            (FourierTransform(period=7, order=2, out_column="res"), "regular_ts"),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+            ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
@@ -1538,6 +1555,11 @@ class TestInverseTransformTrainNewSegments:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {},
             ),
             (
@@ -1907,6 +1929,11 @@ class TestInverseTransformFutureNewSegments:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {},
             ),
             (
@@ -2429,6 +2456,11 @@ class TestInverseTransformFutureWithTarget:
             ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
                 {},
             ),
@@ -2884,6 +2916,11 @@ class TestInverseTransformFutureWithoutTarget:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {},
             ),
             (

--- a/tests/test_transforms/test_inference/test_transform.py
+++ b/tests/test_transforms/test_inference/test_transform.py
@@ -366,6 +366,11 @@ class TestTransformTrain:
             ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
@@ -713,6 +718,11 @@ class TestTransformTrain:
             ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
@@ -972,7 +982,11 @@ class TestTransformTrainSubsetSegments:
                 DateFlagsTransform(out_column="res", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
             ),
-            (FourierTransform(period=7, order=2), "regular_ts"),
+            (FourierTransform(period=7, order=2, out_column="res"), "regular_ts"),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+            ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
@@ -1199,7 +1213,11 @@ class TestTransformFutureSubsetSegments:
                 DateFlagsTransform(out_column="res", in_column="external_timestamp"),
                 "ts_with_external_timestamp",
             ),
-            (FourierTransform(period=7, order=2), "regular_ts"),
+            (FourierTransform(period=7, order=2, out_column="res"), "regular_ts"),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+            ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
@@ -1413,6 +1431,11 @@ class TestTransformTrainNewSegments:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
             (
@@ -1768,6 +1791,11 @@ class TestTransformFutureNewSegments:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
             (
@@ -2206,6 +2234,11 @@ class TestTransformFutureWithTarget:
             ),
             (
                 FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
                 "ts_with_external_int_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
@@ -2620,6 +2653,11 @@ class TestTransformFutureWithoutTarget:
             (
                 FourierTransform(period=7, order=2, out_column="res"),
                 "regular_ts",
+                {"create": {"res_1", "res_2", "res_3", "res_4"}},
+            ),
+            (
+                FourierTransform(period=7, order=2, out_column="res", in_column="external_timestamp"),
+                "ts_with_external_timestamp",
                 {"create": {"res_1", "res_2", "res_3", "res_4"}},
             ),
             (

--- a/tests/test_transforms/test_timestamp/test_fourier_transform.py
+++ b/tests/test_transforms/test_timestamp/test_fourier_transform.py
@@ -11,6 +11,7 @@ from etna.models import LinearPerSegmentModel
 from etna.transforms.timestamp import FourierTransform
 from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
+from tests.utils import convert_ts_to_int_timestamp
 
 
 def add_seasonality(series: pd.Series, period: int, magnitude: float) -> pd.Series:
@@ -69,7 +70,8 @@ def example_ts_external_datetime_timestamp(example_df):
     df_exog.loc[df_exog["segment"] == "segment_1", "external_timestamp"] += pd.Timedelta("6H")
     df_exog_wide = TSDataset.to_dataset(df_exog)
     ts = TSDataset(df=df_wide, df_exog=df_exog_wide, freq="H")
-    return ts
+    ts_int_index = convert_ts_to_int_timestamp(ts=ts, shift=10)
+    return ts_int_index
 
 
 @pytest.fixture
@@ -113,7 +115,8 @@ def example_ts_external_int_timestamp(example_df):
     df_exog.loc[df_exog["segment"] == "segment_1", "external_timestamp"] += 6
     df_exog_wide = TSDataset.to_dataset(df_exog)
     ts = TSDataset(df=df_wide, df_exog=df_exog_wide, freq="H")
-    return ts
+    ts_int_index = convert_ts_to_int_timestamp(ts=ts, shift=10)
+    return ts_int_index
 
 
 @pytest.fixture


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
- Add more inference tests for `FourierTransform`
- Fix `FourierTransform` on integer index, update tests

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
