### PR TITLE
Update `ExogShiftTransform` to handle integer timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update pipelines to handle integer timestamp ([#241](https://github.com/etna-team/etna/pull/241))
 - Add `timestamp_range` and refactor code with it ([#244](https://github.com/etna-team/etna/pull/244))
 - Update CLI to handle integer timestamp ([#246](https://github.com/etna-team/etna/pull/246))
+- Update `ExogShiftTransform` to handle integer timestamp ([#254](https://github.com/etna-team/etna/pull/254))
 
 ### Fixed
 - 

--- a/etna/transforms/math/lags.py
+++ b/etna/transforms/math/lags.py
@@ -96,6 +96,7 @@ class LagTransform(IrreversibleTransform):
         features = df.loc[:, pd.IndexSlice[:, self.in_column]]
         for lag in self.lags:
             column_name = self._get_column_name(lag)
+            # this could lead to type changes due to introduction of NaNs
             transformed_features = features.shift(lag)
             transformed_features.columns = pd.MultiIndex.from_product([segments, [column_name]])
             all_transformed_features.append(transformed_features)
@@ -169,9 +170,9 @@ class ExogShiftTransform(IrreversibleTransform):
                 feature = df_exog.loc[:, pd.IndexSlice[:, name]]
 
                 na_mask = pd.isna(feature).any(axis=1)
-                last_date = feature.index[~na_mask].max()
+                last_timestamp = feature.index[~na_mask].max()
 
-                exog_last_timestamp[name] = last_date
+                exog_last_timestamp[name] = last_timestamp
 
         self._exog_last_timestamp = exog_last_timestamp
 
@@ -287,9 +288,7 @@ class ExogShiftTransform(IrreversibleTransform):
             feature = df.loc[:, pd.IndexSlice[:, feature_name]]
 
             if shift > 0:
-                # TODO: разобраться с этим моментом и преобразованием типов
-                # shifted_feature = feature.shift(shift, freq=self._freq)
-                # shifted_feature = shifted_feature.loc[shifted_feature.index.intersection(df.index)]
+                # this could lead to type changes due to introduction of NaNs
                 shifted_feature = feature.shift(shift)
 
                 column_name = f"{feature_name}_shift_{shift}"

--- a/etna/transforms/math/lags.py
+++ b/etna/transforms/math/lags.py
@@ -241,7 +241,7 @@ class ExogShiftTransform(IrreversibleTransform):
         if not self._auto:
             return self.lag  # type: ignore
 
-        if self._exog_last_timestamp is None or self._freq is _DEFAULT_FREQ:
+        if self._exog_last_timestamp is None:
             raise ValueError("Call `fit()` method before estimating exog shifts!")
 
         last_date = df.index.max()

--- a/tests/test_transforms/test_inference/conftest.py
+++ b/tests/test_transforms/test_inference/conftest.py
@@ -55,6 +55,25 @@ def ts_with_exog(regular_ts) -> TSDataset:
 
 
 @pytest.fixture
+def ts_with_exog_to_shift(regular_ts) -> TSDataset:
+    df = regular_ts.to_pandas(flatten=True)
+    periods = 120
+    timestamp = pd.date_range("2020-01-01", periods=periods)
+    feature = timestamp.weekday.astype(float)
+    df_exog_common = pd.DataFrame(
+        {
+            "timestamp": timestamp,
+            "feature_1": feature[:100].tolist() + [None] * 20,
+            "feature_2": feature[:105].tolist() + [None] * 15,
+            "feature_3": feature,
+        }
+    )
+    df_exog_wide = duplicate_data(df=df_exog_common, segments=regular_ts.segments)
+    ts = TSDataset(df=TSDataset.to_dataset(df).iloc[5:], df_exog=df_exog_wide, freq="D")
+    return ts
+
+
+@pytest.fixture
 def ts_with_external_timestamp(regular_ts) -> TSDataset:
     df = regular_ts.to_pandas(flatten=True)
     df_exog = df.copy()

--- a/tests/test_transforms/test_inference/test_inverse_transform.py
+++ b/tests/test_transforms/test_inference/test_inverse_transform.py
@@ -18,6 +18,7 @@ from etna.transforms import DensityOutliersTransform
 from etna.transforms import DeseasonalityTransform
 from etna.transforms import DifferencingTransform
 from etna.transforms import EventTransform
+from etna.transforms import ExogShiftTransform
 from etna.transforms import FilterFeaturesTransform
 from etna.transforms import FourierTransform
 from etna.transforms import GaleShapleyFeatureSelectionTransform
@@ -211,6 +212,11 @@ class TestInverseTransformTrain:
             (
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
                 {},
             ),
             (
@@ -597,6 +603,11 @@ class TestInverseTransformTrain:
                 {},
             ),
             (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {},
+            ),
+            (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
                 "regular_ts",
                 {},
@@ -952,6 +963,10 @@ class TestInverseTransformTrainSubsetSegments:
             (AddConstTransform(in_column="target", value=1, inplace=True), "regular_ts"),
             (LagTransform(in_column="target", lags=[1, 2, 3]), "regular_ts"),
             (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+            ),
+            (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False),
                 "regular_ts",
             ),
@@ -1171,6 +1186,10 @@ class TestInverseTransformFutureSubsetSegments:
             (AddConstTransform(in_column="target", value=1, inplace=True), "regular_ts"),
             (AddConstTransform(in_column="positive", value=1, inplace=True), "ts_with_exog"),
             (LagTransform(in_column="target", lags=[1, 2, 3]), "regular_ts"),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+            ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False),
                 "regular_ts",
@@ -1424,6 +1443,11 @@ class TestInverseTransformTrainNewSegments:
             (
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
                 {},
             ),
             (
@@ -1751,6 +1775,11 @@ class TestInverseTransformFutureNewSegments:
             (
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
                 {},
             ),
             (
@@ -2244,6 +2273,11 @@ class TestInverseTransformFutureWithTarget:
                 {},
             ),
             (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {},
+            ),
+            (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
                 "regular_ts",
                 {},
@@ -2652,6 +2686,11 @@ class TestInverseTransformFutureWithoutTarget:
             (
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
+                {},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
                 {},
             ),
             (

--- a/tests/test_transforms/test_inference/test_transform.py
+++ b/tests/test_transforms/test_inference/test_transform.py
@@ -18,6 +18,7 @@ from etna.transforms import DensityOutliersTransform
 from etna.transforms import DeseasonalityTransform
 from etna.transforms import DifferencingTransform
 from etna.transforms import EventTransform
+from etna.transforms import ExogShiftTransform
 from etna.transforms import FilterFeaturesTransform
 from etna.transforms import FourierTransform
 from etna.transforms import GaleShapleyFeatureSelectionTransform
@@ -164,6 +165,11 @@ class TestTransformTrain:
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
                 {"create": {"res_1", "res_2", "res_3"}},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
             ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
@@ -503,6 +509,11 @@ class TestTransformTrain:
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
                 {"create": {"res_1", "res_2", "res_3"}},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
             ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
@@ -897,6 +908,7 @@ class TestTransformTrainSubsetSegments:
             (AddConstTransform(in_column="target", value=1, inplace=False), "regular_ts"),
             (AddConstTransform(in_column="target", value=1, inplace=True), "regular_ts"),
             (LagTransform(in_column="target", lags=[1, 2, 3]), "regular_ts"),
+            (ExogShiftTransform(lag="auto", horizon=7), "ts_with_exog_to_shift"),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False),
                 "regular_ts",
@@ -1104,6 +1116,10 @@ class TestTransformFutureSubsetSegments:
             (AddConstTransform(in_column="target", value=1, inplace=True), "regular_ts"),
             (AddConstTransform(in_column="positive", value=1, inplace=True), "ts_with_exog"),
             (LagTransform(in_column="target", lags=[1, 2, 3]), "regular_ts"),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+            ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False),
                 "regular_ts",
@@ -1315,6 +1331,11 @@ class TestTransformTrainNewSegments:
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
                 {"create": {"res_1", "res_2", "res_3"}},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
             ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
@@ -1629,6 +1650,11 @@ class TestTransformFutureNewSegments:
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
                 {"create": {"res_1", "res_2", "res_3"}},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=7),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
             ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
@@ -2030,6 +2056,11 @@ class TestTransformFutureWithTarget:
                 {"create": {"res_1", "res_2", "res_3"}},
             ),
             (
+                ExogShiftTransform(lag="auto", horizon=64),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
+            ),
+            (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),
                 "regular_ts",
                 {"create": {"res"}},
@@ -2398,6 +2429,11 @@ class TestTransformFutureWithoutTarget:
                 LagTransform(in_column="target", lags=[1, 2, 3], out_column="res"),
                 "regular_ts",
                 {"create": {"res_1", "res_2", "res_3"}},
+            ),
+            (
+                ExogShiftTransform(lag="auto", horizon=35),
+                "ts_with_exog_to_shift",
+                {"create": {"feature_1_shift_7", "feature_2_shift_2"}, "remove": {"feature_1", "feature_2"}},
             ),
             (
                 LambdaTransform(in_column="target", transform_func=lambda x: x + 1, inplace=False, out_column="res"),

--- a/tests/test_transforms/test_math/test_exog_shift_transform.py
+++ b/tests/test_transforms/test_math/test_exog_shift_transform.py
@@ -17,7 +17,6 @@ def build_df_exog_with_nans(freq="D"):
             "feat1": [1, 2, 3, 4, None] + [1, 2, 3, 4, 5],
             "feat2": [1, 2, 3, None, None] + [1, 2, 3, None, None],
             "feat3": [1, 2, 3, 4, 5] + [1, 2, 3, 4, 5],
-            "feat4": ["A", "B", "C", "D", None] + ["A", "B", "C", "D", "E"]
         }
     )
 
@@ -184,8 +183,8 @@ def test_transformed_names(ts_name, lag, horizon, expected, request):
 @pytest.mark.parametrize(
     "lag,horizon,expected",
     (
-        # (1, None, {"feat1_shift_1", "feat2_shift_1", "feat3_shift_1", "target"}),
-        # ("auto", 1, {"feat1_shift_1", "feat2_shift_2", "feat3", "target"}),
+        (1, None, {"feat1_shift_1", "feat2_shift_1", "feat3_shift_1", "target"}),
+        ("auto", 1, {"feat1_shift_1", "feat2_shift_2", "feat3", "target"}),
         ("auto", 2, {"feat1_shift_2", "feat2_shift_3", "feat3_shift_1", "target"}),
     ),
 )
@@ -193,7 +192,7 @@ def test_transformed_names(ts_name, lag, horizon, expected, request):
     "ts_name",
     (
         "ts_with_exogs",
-        # "ts_with_exogs_ms_freq",
+        "ts_with_exogs_ms_freq",
     ),
 )
 def test_transform_int_features(ts_name, lag, horizon, expected, request):

--- a/tests/test_transforms/test_math/test_exog_shift_transform.py
+++ b/tests/test_transforms/test_math/test_exog_shift_transform.py
@@ -181,11 +181,11 @@ def test_transformed_names(ts_name, lag, horizon, expected, request):
 
 
 @pytest.mark.parametrize(
-    "lag,horizon,expected",
+    "lag,horizon,expected_types",
     (
-        (1, None, {"feat1_shift_1", "feat2_shift_1", "feat3_shift_1", "target"}),
-        ("auto", 1, {"feat1_shift_1", "feat2_shift_2", "feat3", "target"}),
-        ("auto", 2, {"feat1_shift_2", "feat2_shift_3", "feat3_shift_1", "target"}),
+        (1, None, {"feat1_shift_1": "float", "feat2_shift_1": "float", "feat3_shift_1": "float", "target": "float"}),
+        ("auto", 1, {"feat1_shift_1": "float", "feat2_shift_2": "float", "feat3": "int", "target": "float"}),
+        ("auto", 2, {"feat1_shift_2": "float", "feat2_shift_3": "float", "feat3_shift_1": "float", "target": "float"}),
     ),
 )
 @pytest.mark.parametrize(
@@ -195,13 +195,14 @@ def test_transformed_names(ts_name, lag, horizon, expected, request):
         "ts_with_exogs_ms_freq",
     ),
 )
-def test_transform_int_features(ts_name, lag, horizon, expected, request):
+def test_transform_type_changes(ts_name, lag, horizon, expected_types, request):
     ts = request.getfixturevalue(ts_name)
 
     t = ExogShiftTransform(lag=lag, horizon=horizon)
-    transformed = t.fit_transform(ts=ts)
-    column_names = transformed.df.columns.get_level_values("feature")
-    assert set(column_names) == expected
+    transformed = t.fit_transform(ts=ts).to_pandas(flatten=True)
+    dtypes = transformed.dtypes
+    for column, expected_dtype in expected_types.items():
+        assert dtypes[column] == expected_dtype
 
 
 @pytest.mark.parametrize("lag", (3, "auto"))

--- a/tests/test_transforms/test_math/test_lag_transform.py
+++ b/tests/test_transforms/test_math/test_lag_transform.py
@@ -111,6 +111,18 @@ def test_lags_values_two_segments(lags: Union[int, Sequence[int]], int_ts_two_se
             assert_almost_equal(true_values.values, lags_df[segment, f"regressor_lag_feature_{lag}"].values)
 
 
+@pytest.mark.parametrize(
+    "lags, expected_types", [(3, {"lag_1": "float", "lag_2": "float", "lag_3": "float", "target": "int"})]
+)
+def test_transform_type_changes(lags, expected_types, int_ts_two_segments):
+    ts = int_ts_two_segments
+    lf = LagTransform(in_column="target", lags=lags, out_column="lag")
+    transformed = lf.fit_transform(ts=ts).to_pandas(flatten=True)
+    dtypes = transformed.dtypes
+    for column, expected_dtype in expected_types.items():
+        assert dtypes[column] == expected_dtype
+
+
 @pytest.mark.parametrize("lags", (0, -1, (10, 15, -2)))
 def test_invalid_lags_value_two_segments(lags):
     """Test that LagTransform can't be created with non-positive lags."""


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #247.

## Closing issues
Closes #247.