### PR TITLE
Speedup timestamp transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update internal datasets to work with unaligned data ([#292](https://github.com/etna-team/etna/pull/292))
 - 
 - 
-- 
+- Speed up "timestamp" transforms ([#295](https://github.com/etna-team/etna/pull/295)
 - 
 - 
 - 

--- a/etna/transforms/timestamp/date_flags.py
+++ b/etna/transforms/timestamp/date_flags.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from etna.datasets import TSDataset
+from etna.datasets import duplicate_data
 from etna.distributions import BaseDistribution
 from etna.distributions import CategoricalDistribution
 from etna.transforms.base import IrreversibleTransform
@@ -290,16 +291,9 @@ class DateFlagsTransform(IrreversibleTransform):
             features = self._compute_features(timestamps=timestamps)
             features.index = df.index
 
-            dataframes = []
-            for seg in df.columns.get_level_values("segment").unique():
-                tmp = df[seg].join(features)
-                _idx = tmp.columns.to_frame()
-                _idx.insert(0, "segment", seg)
-                tmp.columns = pd.MultiIndex.from_frame(_idx)
-                dataframes.append(tmp)
-            result = pd.concat(dataframes, axis=1).sort_index(axis=1)
-            result.columns.names = ["segment", "feature"]
-
+            segments = df.columns.get_level_values("segment").unique().tolist()
+            result = duplicate_data(df=features.reset_index(), segments=segments)
+            result = pd.concat([df, result], axis=1).sort_index(axis=1)
         else:
             flat_df = TSDataset.to_flatten(df=df, features=[self.in_column])
             features = self._compute_features(timestamps=flat_df[self.in_column])

--- a/etna/transforms/timestamp/fourier.py
+++ b/etna/transforms/timestamp/fourier.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from etna.datasets import TSDataset
+from etna.datasets import duplicate_data
 from etna.datasets.utils import determine_freq
 from etna.datasets.utils import determine_num_steps
 from etna.distributions import BaseDistribution
@@ -271,16 +272,9 @@ class FourierTransform(IrreversibleTransform):
 
     @staticmethod
     def _construct_answer_for_index(df: pd.DataFrame, features: pd.DataFrame) -> pd.DataFrame:
-        dataframes = []
-        for seg in df.columns.get_level_values("segment").unique():
-            tmp = df[seg].join(features)
-            _idx = tmp.columns.to_frame()
-            _idx.insert(0, "segment", seg)
-            tmp.columns = pd.MultiIndex.from_frame(_idx)
-            dataframes.append(tmp)
-
-        result = pd.concat(dataframes, axis=1).sort_index(axis=1)
-        result.columns.names = ["segment", "feature"]
+        segments = df.columns.get_level_values("segment").unique().tolist()
+        result = duplicate_data(df=features.reset_index(), segments=segments)
+        result = pd.concat([df, result], axis=1).sort_index(axis=1)
         return result
 
     def _compute_features(self, timestamps: pd.Series) -> pd.DataFrame:

--- a/etna/transforms/timestamp/holiday.py
+++ b/etna/transforms/timestamp/holiday.py
@@ -273,7 +273,7 @@ class HolidayTransform(IrreversibleTransform):
                 elif t in self.holidays:
                     values.append(self.holidays[t])
                 else:
-                    values.append(self._no_holiday_name)
+                    values.append(self._no_holiday_name)  # type: ignore
         elif self._mode is HolidayTransformMode.binary:
             values = [int(x in self.holidays) if x is not pd.NaT else pd.NA for x in timestamps]
         else:

--- a/etna/transforms/timestamp/holiday.py
+++ b/etna/transforms/timestamp/holiday.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import cast
 
 import holidays
+import numpy as np
 import pandas as pd
 from pandas.tseries.offsets import MonthBegin
 from pandas.tseries.offsets import MonthEnd
@@ -248,7 +249,6 @@ class HolidayTransform(IrreversibleTransform):
         return self
 
     def _compute_feature(self, timestamps: pd.Series) -> pd.Series:
-        values = None
         dtype = "float"
         if self._mode is HolidayTransformMode.binary or self._mode is HolidayTransformMode.category:
             dtype = "category"
@@ -258,7 +258,7 @@ class HolidayTransform(IrreversibleTransform):
             values = []
             for dt in timestamps:
                 if dt is pd.NaT:
-                    values.append(pd.NA)
+                    values.append(np.NAN)
                 else:
                     start_date, end_date = define_period(date_offset, pd.Timestamp(dt), self._freq)
                     date_range = pd.date_range(start=start_date, end=end_date, freq="D")
@@ -278,7 +278,7 @@ class HolidayTransform(IrreversibleTransform):
             values = [int(x in self.holidays) if x is not pd.NaT else pd.NA for x in timestamps]
         else:
             assert_never(self._mode)
-        result = pd.Series(values, index=timestamps, dtype=dtype)
+        result = pd.Series(values, index=timestamps, dtype=dtype, name=self._get_column_name())
 
         return result
 

--- a/etna/transforms/timestamp/time_flags.py
+++ b/etna/transforms/timestamp/time_flags.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 
 from etna.datasets import TSDataset
+from etna.datasets import duplicate_data
 from etna.distributions import BaseDistribution
 from etna.distributions import CategoricalDistribution
 from etna.transforms.base import IrreversibleTransform
@@ -213,15 +214,9 @@ class TimeFlagsTransform(IrreversibleTransform):
             features = self._compute_features(timestamps=timestamps)
             features.index = df.index
 
-            dataframes = []
-            for seg in df.columns.get_level_values("segment").unique():
-                tmp = df[seg].join(features)
-                _idx = tmp.columns.to_frame()
-                _idx.insert(0, "segment", seg)
-                tmp.columns = pd.MultiIndex.from_frame(_idx)
-                dataframes.append(tmp)
-            result = pd.concat(dataframes, axis=1).sort_index(axis=1)
-            result.columns.names = ["segment", "feature"]
+            segments = df.columns.get_level_values("segment").unique().tolist()
+            result = duplicate_data(df=features.reset_index(), segments=segments)
+            result = pd.concat([df, result], axis=1).sort_index(axis=1)
 
         else:
             flat_df = TSDataset.to_flatten(df=df, features=[self.in_column])


### PR DESCRIPTION
## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Flame graphs(before)
- DateFlagsTransform
<img width="1350" alt="Снимок экрана 2024-04-04 в 15 16 42" src="https://github.com/etna-team/etna/assets/55380696/1e9bd772-5871-4976-b02b-144b0ddf775d">

- TimeFlagsTransform
<img width="1370" alt="Снимок экрана 2024-04-04 в 15 18 43" src="https://github.com/etna-team/etna/assets/55380696/31d8e60c-6156-4e0d-887d-cbf7ff4062b8">

- FourierTransform
<img width="1450" alt="Снимок экрана 2024-04-04 в 15 17 34" src="https://github.com/etna-team/etna/assets/55380696/28750471-1c12-4729-9ea5-9c74fbc544c4">

- HolidaysTransform
<img width="956" alt="Снимок экрана 2024-04-04 в 15 33 23" src="https://github.com/etna-team/etna/assets/55380696/ce75237e-0b03-4dfa-bae3-4d1bf9603a41">


## Proposed Changes
- Rewrite answer construction with `dupplicate_data`
https://github.com/etna-team/etna/blob/f064bcbc01b565218a7f7b161c63b3cabb52d7e9/etna/transforms/timestamp/time_flags.py#L216
- Refactor `HolidaysTransform` with `dupplicate_data`
- Speedup casting in `HolidaysTransform`  

## Flame graphs(after)
- DateFlagsTransform(49c -> 18c = x2.7)
<img width="1053" alt="Снимок экрана 2024-04-04 в 15 19 26" src="https://github.com/etna-team/etna/assets/55380696/72a38cab-901a-4eba-a0b3-65ddee2a5418">

- TimeFlagsTransform(32c -> 13c = x2.5)
<img width="1042" alt="Снимок экрана 2024-04-04 в 15 20 44" src="https://github.com/etna-team/etna/assets/55380696/ff41b415-d31d-4378-ad12-3c65b1f458f7">

- FourierTransform(50c -> 12c = x4)
<img width="977" alt="Снимок экрана 2024-04-04 в 15 20 22" src="https://github.com/etna-team/etna/assets/55380696/845f072e-bab8-4e46-9fa1-cbc83abb5cd6">

- HolidaysTransform(10c -> 6c = x1.5)
<img width="804" alt="Снимок экрана 2024-04-04 в 15 35 48" src="https://github.com/etna-team/etna/assets/55380696/9c58692d-92b8-4dec-81ba-57c233dd68fb">

## Additional thoughts

1. `update_dataset` takes 40% of time, see issue #196 
2. transform takes 25% of time
    - 14% for `concat` — we can get rid of it fixing the update_dataset logic, now we need to concat "target" to the features
    - 12% for `duplicate_data` — we can try to further speedup `to_dataset` 
3. We can try to think about not duplicating static covariates
4. There are several places for further optimizations in timestamp transforms, we can try to profile them in separate issues


## Code to reproduce

```
from etna.datasets import TSDataset, generate_ar_df
from etna.transforms import DateFlagsTransform, TimeFlagsTransform, HolidayTransform, FourierTransform

df = generate_ar_df(n_segments=10000, periods=100, start_time="2000-01-01")
df = TSDataset.to_dataset(df)
ts = TSDataset(df=df, freq="D")

transform = DateFlagsTransform(
    day_number_in_week=True,
    day_number_in_month=True,
    day_number_in_year=True,
    week_number_in_month=True,
    week_number_in_year=True,
    month_number_in_year=True,
    season_number=True,
    year_number=True,
    is_weekend=True,
    out_column="df"
)

transform = TimeFlagsTransform(
    minute_in_hour_number=True,
    fifteen_minutes_in_hour_number=True,
    hour_number=True,
    half_hour_number=True,
    half_day_number=True,
    one_third_day_number=True,
    out_column="df"
)

transform = FourierTransform(
    period=365.5,
    order=10,
    out_column="df"
)

transform = HolidayTransform(
    out_column="df"
)

transform.fit_transform(ts)

``` 
## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #3 
