### PR TITLE
Fix `101-get-started` notebook to be rendered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - 
 - 
-- 
+- Fix `101-get-started` notebook to be rendered correctly ([#340](https://github.com/etna-team/etna/pull/340))
 - 
 - 
 - 

--- a/examples/101-get_started.ipynb
+++ b/examples/101-get_started.ipynb
@@ -155,6 +155,7 @@
     "Library works with a special data structure called `TSDataset`. It stores all the necessary information to work with multiple time series.\n",
     "\n",
     "To create an instance of `TSDataset` we should reformat our `df` into one of two supported formats:\n",
+    "\n",
     "- Long format\n",
     "  - Has columns `timestamp`, `segment`, `target`\n",
     "  - Column `timestamp` stores timestamp values\n",
@@ -1529,7 +1530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #302.

## Closing issues
Closes #302.