### PR TITLE
Fix `DeepStateModel` forecasting problem with horizon=1 

### DIFF
--- a/etna/models/nn/deepstate/state_space_model.py
+++ b/etna/models/nn/deepstate/state_space_model.py
@@ -293,7 +293,7 @@ class SeasonalitySSM(LevelSSM):
         :
             Emission coefficient matrix.
         """
-        emission_coeff = one_hot(datetime_index.squeeze(-1), num_classes=self.latent_dim())
+        emission_coeff = one_hot(datetime_index, num_classes=self.latent_dim())
         return emission_coeff.float()
 
     def generate_datetime_index(self, timestamps: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes https://github.com/etna-team/etna/issues/338 . 