### PR TITLE
Change default value of `fast_redundancy` in `MRMRFeatureSelectionTransform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement non-empty `params_to_tune` for `StackingEnsemble` ([#561](https://github.com/etna-team/etna/pull/561))
 - 
 - **Breaking:** Make `level_names` property of `HierarchicalStructure` read-only ([#582](https://github.com/etna-team/etna/pull/582))
-- 
+- **Breaking:** Set `fast_redundancy=True` as a default value in `MRMRFeatureSelectionTransform` ([#592](https://github.com/etna-team/etna/pull/592))
 - 
 - 
 - 

--- a/etna/analysis/feature_selection/mrmr_selection.py
+++ b/etna/analysis/feature_selection/mrmr_selection.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import Enum
 from typing import List
 
@@ -76,11 +75,6 @@ def mrmr(
     selected_features: List[str]
         list of ``top_k`` selected regressors, sorted by their importance
     """
-    if not fast_redundancy:
-        warnings.warn(
-            "Option `fast_redundancy=False` was added for backward compatibility and will be removed in etna 3.0.0.",
-            DeprecationWarning,
-        )
     relevance_aggregation_fn = AGGREGATION_FN[AggregationMode(relevance_aggregation_mode)]
     redundancy_aggregation_fn = AGGREGATION_FN[AggregationMode(redundancy_aggregation_mode)]
 

--- a/etna/transforms/feature_selection/feature_importance.py
+++ b/etna/transforms/feature_selection/feature_importance.py
@@ -171,7 +171,7 @@ class MRMRFeatureSelectionTransform(BaseFeatureSelectionTransform):
         relevance_table: RelevanceTable,
         top_k: int,
         features_to_use: Union[List[str], Literal["all"]] = "all",
-        fast_redundancy: bool = False,
+        fast_redundancy: bool = True,
         drop_zero: bool = False,
         relevance_aggregation_mode: str = AggregationMode.mean,
         redundancy_aggregation_mode: str = AggregationMode.mean,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,6 @@ filterwarnings = [
     # etna warnings
     "ignore: TSDataset freq can't be inferred",
     "ignore: You probably set wrong freq. Discovered freq in you data",
-    "ignore: Option `fast_redundancy=False` was added for backward compatibility and will be removed in etna 3.0.0.",
     "ignore: Some regressors don't have enough values",
     "ignore: Segments contains NaNs in the last timestamps",
     "ignore: Given top_k=.* is bigger than n_features=.*. Transform will not filter",

--- a/tests/test_analysis/test_feature_selection/test_mrmr.py
+++ b/tests/test_analysis/test_feature_selection/test_mrmr.py
@@ -176,13 +176,6 @@ def test_mrmr_select_less_redundant_regressor_diff_start(
     assert set(selected_regressors) == set(high_relevance_high_redundancy_problem_diff_starts["expected_answer"])
 
 
-def test_fast_redundancy_deprecation_warning(df_with_regressors):
-    df, regressors = df_with_regressors["df"], df_with_regressors["regressors"]
-    relevance_table = ModelRelevanceTable()(df=df, df_exog=regressors, model=RandomForestRegressor())
-    with pytest.warns(DeprecationWarning, match="Option `fast_redundancy=False` was added for backward compatibility"):
-        mrmr(relevance_table=relevance_table, regressors=regressors, top_k=2, fast_redundancy=False)
-
-
 @pytest.mark.parametrize("fast_redundancy", [True, False])
 def test_mrmr_with_castable_categorical_regressor(df_with_regressors, fast_redundancy):
     df, regressors = df_with_regressors["df"], df_with_regressors["regressors"]


### PR DESCRIPTION
## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

## Closing issues
closes #591 
