### PR TITLE
Drop  prediction intervals in `get_residuals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typing for `dtype` parameter of `Chronos`-based models ([#623](https://github.com/etna-team/etna/pull/623))
 - Fix `No space left on device error` during building docker images ([#632](https://github.com/etna-team/etna/pull/632))
 - Fix error with `repr` of `DeepStateModel` and `LevelTrendSSM` ([#642](https://github.com/etna-team/etna/pull/642))
+- Fix `get_residuals` to drop prediction intervals ([#645](https://github.com/etna-team/etna/pull/645))
 
 ### Removed
 - **Breaking:** Remove `FutureMixin`, `OutliersTransform.outliers_timestamps` and `OutliersTransform.original_values` ([#577](https://github.com/etna-team/etna/pull/577))

--- a/etna/analysis/forecast/utils.py
+++ b/etna/analysis/forecast/utils.py
@@ -44,6 +44,7 @@ def get_residuals(forecast_ts_list: List["TSDataset"], ts: "TSDataset") -> "TSDa
     # remove target components
     ts_copy = deepcopy(ts)
     ts_copy.drop_target_components()
+    ts_copy.drop_prediction_intervals()
 
     # find the residuals
     true_df = ts_copy[forecast_df.index, :, :]

--- a/tests/test_analysis/test_forecast/test_utils.py
+++ b/tests/test_analysis/test_forecast/test_utils.py
@@ -31,7 +31,7 @@ def residuals():
         TSDataset(df=forecast_df.loc[df["timestamp"] >= timestamp[55]], freq=pd.offsets.Day()),
     ]
 
-    residuals_df = ts[timestamp[10:], :, :]
+    residuals_df = ts[ts.timestamps[10:], :, :]
     residuals_df.loc[:, pd.IndexSlice["segment_0", "target"]] += 1
     residuals_df.loc[:, pd.IndexSlice["segment_1", "target"]] -= 1
 
@@ -86,6 +86,7 @@ def test_get_residuals_with_invervals(residuals_with_intervals):
     actual_residuals = get_residuals(forecast_ts_list=forecast_ts_list, ts=ts)
     assert "target_0.025" not in actual_residuals.features
     assert "target_0.025" not in actual_residuals.prediction_intervals_names
+    pd.testing.assert_frame_equal(actual_residuals._df, residuals_df)
 
 
 def test_get_residuals_not_matching_lengths(residuals):


### PR DESCRIPTION
## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

## Closing issues
closes #438 
