### PR TITLE
Clarify that current native DL models continue fit during calling `fit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `pd.DateOffset` values for `freq` in `TSDataset`, `_SARIMAXBaseAdapter`, `_StatsForecastBaseAdapter`, `_TBATSAdapter`, `_HoltWintersAdapter` ([#640](https://github.com/etna-team/etna/pull/640))
 - Add warning when features are dropped in `make_future` ([#644](https://github.com/etna-team/etna/pull/644))
 - Add `BaseIntervalsMetricWithMissingHandling` with base functionality for metrics for prediction intervals with missing handling. ([#659](https://github.com/etna-team/etna/pull/659))
+- Update native DL models docs with statement that they continue training after each ``fit`` call ([#663](https://github.com/etna-team/etna/pull/663))
 
 ### Changed
 - Optimize dataset updates with `TSDataset.update_columns_from_pandas` ([#522](https://github.com/etna-team/etna/pull/552))

--- a/etna/models/base.py
+++ b/etna/models/base.py
@@ -551,7 +551,7 @@ class DeepBaseModel(DeepBaseAbstractModel, SaveDeepBaseModelMixin, NonPrediction
     def fit(self, ts: TSDataset) -> "DeepBaseModel":
         """Fit model.
 
-         Model continues training after each ``fit`` call.
+        Model continues training after each ``fit`` call.
 
         Parameters
         ----------

--- a/etna/models/base.py
+++ b/etna/models/base.py
@@ -551,6 +551,8 @@ class DeepBaseModel(DeepBaseAbstractModel, SaveDeepBaseModelMixin, NonPrediction
     def fit(self, ts: TSDataset) -> "DeepBaseModel":
         """Fit model.
 
+         Model continues training after each ``fit`` call.
+
         Parameters
         ----------
         ts:


### PR DESCRIPTION
## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/etna-team/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/etna-team/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

## Closing issues
closes #281 
